### PR TITLE
closes #34 changed scope of maven-plugin-api to provided.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
 			<groupId>org.apache.maven</groupId>
 			<artifactId>maven-plugin-api</artifactId>
 			<version>3.8.6</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugin-tools</groupId>


### PR DESCRIPTION
This plugin will be provided by maven itself. So it is not needed to set the scope to complie. It also fixes the rest of the found issues with the scope.