### PR TITLE
do full checkout

### DIFF
--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -15,7 +15,10 @@ jobs:
     if: (contains(github.event.pull_request.labels.*.name, 'PR save to build') && github.event_name != 'push') || (github.event_name == 'push' && github.event.pull_request.action == '')
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout branch
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Set up JDK (8 and 17)
       uses: actions/setup-java@v3
       with:


### PR DESCRIPTION
This helps SonarQube detect blame information. Also use version 4 of checkout action